### PR TITLE
Add SSL support.

### DIFF
--- a/examplebot.py
+++ b/examplebot.py
@@ -61,14 +61,17 @@ def endMOTD(sender, headers, message):
     bot.say(chanName, "The underlying framework is in no way limited to the above functions.")
     bot.say(chanName, "This is merely an example of the framework's usage")
 
+def useSSL(argv):
+    return len (argv) == 6 and argv[5] == "ssl"
+
 # Main program begins here
 if __name__ == "__main__":
-    if len(sys.argv) == 5:
+    if len(sys.argv) == 5 or useSSL(sys.argv):
         server = sys.argv[1]
         port = int(sys.argv[2])
         owner = sys.argv[3]
         chanName = "#" + sys.argv[4]
-        bot = ircBot(server, port, "ExampleBot", "An example bot written with the new IRC bot framework")
+        bot = ircBot(server, port, "ExampleBot", "An example bot written with the new IRC bot framework", ssl=useSSL(sys.argv))
         bot.bind("PRIVMSG", privmsg)
         bot.bind("ACTION", actionmsg)
         bot.bind("376", endMOTD)
@@ -80,6 +83,6 @@ if __name__ == "__main__":
         bot.stop()
         bot.join()
     else:
-        print "Usage: python examplebot.py <server> <port> <your IRC nick> <irc channel (no '#' character please)>"
+        print "Usage: python examplebot.py <server> <port> <your IRC nick> <irc channel (no '#' character please)> <ssl (optional)>"
 
 

--- a/ircbotframe.py
+++ b/ircbotframe.py
@@ -2,6 +2,7 @@ import socket
 import threading
 import re
 import time
+import ssl
 
 class ircOutputBuffer:
     # Delays consecutive messages by at least 1 second.
@@ -73,13 +74,14 @@ class ircInputBuffer:
         return str(line)
 
 class ircBot(threading.Thread):
-    def __init__(self, network, port, name, description):
+    def __init__(self, network, port, name, description, ssl=False):
         threading.Thread.__init__(self)
         self.keepGoing = True
         self.name = name
         self.desc = description
         self.network = network
         self.port = port
+        self.ssl = ssl
         self.identifyNickCommands = []
         self.identifyLock = False
         self.binds = []
@@ -179,6 +181,8 @@ class ircBot(threading.Thread):
         self.__debugPrint("Connecting...")
         self.irc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.irc.connect((self.network, self.port))
+        if self.ssl:
+            self.irc = ssl.wrap_socket(self.irc)
         self.inBuf = ircInputBuffer(self.irc)
         self.outBuf = ircOutputBuffer(self.irc)
         self.outBuf.sendBuffered("NICK " + self.name)


### PR DESCRIPTION
The feature is turned off by default, but can be invoked by including "ssl=True" when creating an ircBot object.
An example use case is included in examplebot.py.
